### PR TITLE
Cache IList size outside of cycles…

### DIFF
--- a/Vostok.ClusterClient.Core/Ordering/Weighed/ReplicaWeightCalculator.cs
+++ b/Vostok.ClusterClient.Core/Ordering/Weighed/ReplicaWeightCalculator.cs
@@ -44,7 +44,8 @@ namespace Vostok.Clusterclient.Core.Ordering.Weighed
         {
             var weight = initialWeight;
 
-            for (var index = 0; index < modifiers.Count; index++)
+            var modifiersCount = modifiers.Count;
+            for (var index = 0; index < modifiersCount; index++)
             {
                 var modifier = modifiers[index];
                 modifier.Modify(replica, allReplicas, storageProvider, request, parameters, ref weight);

--- a/Vostok.ClusterClient.Core/Ordering/Weighed/WeighedReplicaOrdering.cs
+++ b/Vostok.ClusterClient.Core/Ordering/Weighed/WeighedReplicaOrdering.cs
@@ -84,7 +84,8 @@ namespace Vostok.Clusterclient.Core.Ordering.Weighed
 
             var count = 0;
             var weightsSum = 0.0;
-            for (var index = 0; index < replicas.Count; index++)
+            var replicasCount = replicas.Count;
+            for (var index = 0; index < replicasCount; index++)
             {
                 var replica = replicas[index];
                 var weight = weightCalculator.GetWeight(replica, replicas, storageProvider, request, parameters);


### PR DESCRIPTION
to avoid calling the Count virtual property on every iteration. 

We can easily remove the second get_Count virtual call from the cycle.
![image (2)](https://user-images.githubusercontent.com/6929808/221402900-ee8be96e-4a77-440a-a318-691d648b5761.png)


Methods with suffix "2" are like this:
```
var upperBound = iListOverList.Count;
for (int i = 0; i < upperBound; i++)
{ ... }
```
```
|                Method |      Job |  Runtime |      Mean |    Error |   StdDev | Code Size |   Gen0 | Allocated |
|---------------------- |--------- |--------- |----------:|---------:|---------:|----------:|-------:|----------:|
|      ForIListOverList | .Net 6.0 | .NET 6.0 | 188.77 ns | 1.078 ns | 0.956 ns |      98 B |      - |         - |
|     ForIListOverList2 | .Net 6.0 | .NET 6.0 | 116.55 ns | 2.343 ns | 2.192 ns |      82 B |      - |         - |
|      ForIListOverList | .Net 7.0 | .NET 7.0 | 187.49 ns | 0.934 ns | 0.874 ns |      89 B |      - |         - |
|     ForIListOverList2 | .Net 7.0 | .NET 7.0 | 104.76 ns | 2.111 ns | 2.347 ns |      76 B |      - |         - |
```